### PR TITLE
Fixes an issue caused by accessing undefined observable

### DIFF
--- a/packages/lib/src/mobxTracker.js
+++ b/packages/lib/src/mobxTracker.js
@@ -100,7 +100,10 @@ function handleObservableObject(id, name, observableObject, thingToEmit) {
   const mobxActions = Object.getOwnPropertyNames(
     Object.getPrototypeOf(observableObject)
   ).filter(property => {
-    return observableObject[property].isMobxAction;
+    if (observableObject[property]) {
+      return observableObject[property].isMobxAction;
+    }
+    return false;
   });
 
   Object.getOwnPropertyNames(observableObject)


### PR DESCRIPTION
I was having similar issues as seen in issue #5 so I started looking at the code. It looks like it was checking to see if an observable was an action and this caused an error if the observable was undefined or null. I put in a check to make sure the observable returned a value before checking to see if it's an action.